### PR TITLE
modifying groups: :groupname syntax

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,10 +17,10 @@ gem 'jquery-rails'
 gem 'jbuilder', '~> 2.0'
 
 # bundle exec rake doc:rails generates the API under doc/api.
-gem 'sdoc', '~> 0.4.0',          group: :doc
+gem 'sdoc', '~> 0.4.0', :group => :doc
 
 # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
-gem 'spring',        group: :development
+gem 'spring', :group => :development
 
 # Reimplements acts_as_paranoid
 gem 'paranoia', '~> 2.0'


### PR DESCRIPTION
vagrant build complaining about group: :groupname syntax ... reverting to :group => :groupname syntax as a potential fix