### PR TITLE
Revert changes removing Gemfile.lock and schema.rb

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,14 +18,6 @@
 # Ignore common editor files.
 /.idea
 
-
-### Sandon Jurowski
-### Ignore db/schema.rb
-### this file is auto-generated per environment
-### and constantly causing merge issues
-/db/schema.rb
-/Gemfile.lock
-
 # Ignore common filesystem files.
 .DS_Store
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,285 @@
+GIT
+  remote: https://github.com/WebBlocks/WebBlocks.git
+  revision: 2e871cbebef6fa72c1a4d54a61bd60fc7fe64f62
+  specs:
+    web_blocks (2.0.4.dev)
+      compass
+      execjs
+      extend_method
+      facets
+      fork
+      fssm
+      ruby-bower
+      sass-css-importer
+      thor
+      yui-compressor
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    actionmailer (4.1.7)
+      actionpack (= 4.1.7)
+      actionview (= 4.1.7)
+      mail (~> 2.5, >= 2.5.4)
+    actionpack (4.1.7)
+      actionview (= 4.1.7)
+      activesupport (= 4.1.7)
+      rack (~> 1.5.2)
+      rack-test (~> 0.6.2)
+    actionview (4.1.7)
+      activesupport (= 4.1.7)
+      builder (~> 3.1)
+      erubis (~> 2.7.0)
+    activemodel (4.1.7)
+      activesupport (= 4.1.7)
+      builder (~> 3.1)
+    activerecord (4.1.7)
+      activemodel (= 4.1.7)
+      activesupport (= 4.1.7)
+      arel (~> 5.0.0)
+    activerecord-session_store (0.1.0)
+      actionpack (>= 4.0.0, < 5)
+      activerecord (>= 4.0.0, < 5)
+      railties (>= 4.0.0, < 5)
+    activesupport (4.1.7)
+      i18n (~> 0.6, >= 0.6.9)
+      json (~> 1.7, >= 1.7.7)
+      minitest (~> 5.1)
+      thread_safe (~> 0.1)
+      tzinfo (~> 1.1)
+    addressable (2.3.8)
+    arel (5.0.1.20140414130214)
+    awesome_nested_set (3.0.2)
+      activerecord (>= 4.0.0, < 5)
+    bcrypt (3.1.10)
+    builder (3.2.2)
+    capybara (2.4.4)
+      mime-types (>= 1.16)
+      nokogiri (>= 1.3.3)
+      rack (>= 1.0.0)
+      rack-test (>= 0.5.4)
+      xpath (~> 2.0)
+    carrierwave (0.10.0)
+      activemodel (>= 3.2.0)
+      activesupport (>= 3.2.0)
+      json (>= 1.7)
+      mime-types (>= 1.16)
+    chunky_png (1.3.3)
+    compass (1.0.1)
+      chunky_png (~> 1.2)
+      compass-core (~> 1.0.1)
+      compass-import-once (~> 1.0.5)
+      rb-fsevent (>= 0.9.3)
+      rb-inotify (>= 0.9)
+      sass (>= 3.3.13, < 3.5)
+    compass-core (1.0.1)
+      multi_json (~> 1.0)
+      sass (>= 3.3.0, < 3.5)
+    compass-import-once (1.0.5)
+      sass (>= 3.2, < 3.5)
+    coveralls (0.7.1)
+      multi_json (~> 1.3)
+      rest-client
+      simplecov (>= 0.7)
+      term-ansicolor
+      thor
+    daemons (1.1.9)
+    database_cleaner (1.4.1)
+    diff-lcs (1.2.5)
+    docile (1.1.5)
+    elasticsearch (1.0.5)
+      elasticsearch-api (= 1.0.5)
+      elasticsearch-transport (= 1.0.5)
+    elasticsearch-api (1.0.5)
+      multi_json
+    elasticsearch-transport (1.0.5)
+      faraday
+      multi_json
+    email_spec (1.6.0)
+      launchy (~> 2.1)
+      mail (~> 2.2)
+    erubis (2.7.0)
+    eventmachine (1.0.7)
+    execjs (2.2.2)
+    extend_method (1.0.0)
+    facets (2.9.3)
+    factory_girl (4.5.0)
+      activesupport (>= 3.0.0)
+    factory_girl_rails (4.5.0)
+      factory_girl (~> 4.5.0)
+      railties (>= 3.0.0)
+    faraday (0.9.0)
+      multipart-post (>= 1.2, < 3)
+    ffi (1.9.6)
+    foreigner (1.7.4)
+      activerecord (>= 3.0.0)
+    fork (1.0.1)
+    fssm (0.2.10)
+    github-markup (1.3.1)
+      posix-spawn (~> 0.3.8)
+    gravatarify (3.1.1)
+    hike (1.2.3)
+    i18n (0.7.0)
+    jbuilder (2.2.5)
+      activesupport (>= 3.0.0, < 5)
+      multi_json (~> 1.2)
+    jquery-rails (3.1.2)
+      railties (>= 3.0, < 5.0)
+      thor (>= 0.14, < 2.0)
+    json (1.8.2)
+    jwt (1.2.0)
+    launchy (2.4.3)
+      addressable (~> 2.3)
+    letter_opener (1.4.0)
+      launchy (~> 2.2)
+    mail (2.6.3)
+      mime-types (>= 1.16, < 3)
+    mime-types (2.4.3)
+    mini_portile (0.6.2)
+    minitest (5.5.1)
+    multi_json (1.10.1)
+    multi_xml (0.5.5)
+    multipart-post (2.0.0)
+    mysql2 (0.3.17)
+    netrc (0.10.3)
+    nokogiri (1.6.6.2)
+      mini_portile (~> 0.6.0)
+    oauth2 (1.0.0)
+      faraday (>= 0.8, < 0.10)
+      jwt (~> 1.0)
+      multi_json (~> 1.3)
+      multi_xml (~> 0.5)
+      rack (~> 1.2)
+    paranoia (2.0.4)
+      activerecord (~> 4.0)
+    posix-spawn (0.3.9)
+    rack (1.5.2)
+    rack-test (0.6.3)
+      rack (>= 1.0)
+    rails (4.1.7)
+      actionmailer (= 4.1.7)
+      actionpack (= 4.1.7)
+      actionview (= 4.1.7)
+      activemodel (= 4.1.7)
+      activerecord (= 4.1.7)
+      activesupport (= 4.1.7)
+      bundler (>= 1.3.0, < 2.0)
+      railties (= 4.1.7)
+      sprockets-rails (~> 2.0)
+    railties (4.1.7)
+      actionpack (= 4.1.7)
+      activesupport (= 4.1.7)
+      rake (>= 0.8.7)
+      thor (>= 0.18.1, < 2.0)
+    rake (10.4.2)
+    rb-fsevent (0.9.4)
+    rb-inotify (0.9.5)
+      ffi (>= 0.5.0)
+    rdoc (4.2.0)
+      json (~> 1.4)
+    redcarpet (3.2.2)
+    rest-client (1.7.3)
+      mime-types (>= 1.16, < 3.0)
+      netrc (~> 0.7)
+    rspec-activemodel-mocks (1.0.1)
+      activemodel (>= 3.0)
+      activesupport (>= 3.0)
+      rspec-mocks (>= 2.99, < 4.0)
+    rspec-core (3.2.3)
+      rspec-support (~> 3.2.0)
+    rspec-expectations (3.2.1)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.2.0)
+    rspec-mocks (3.2.1)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.2.0)
+    rspec-rails (3.2.1)
+      actionpack (>= 3.0, < 4.3)
+      activesupport (>= 3.0, < 4.3)
+      railties (>= 3.0, < 4.3)
+      rspec-core (~> 3.2.0)
+      rspec-expectations (~> 3.2.0)
+      rspec-mocks (~> 3.2.0)
+      rspec-support (~> 3.2.0)
+    rspec-support (3.2.2)
+    ruby-bower (0.0.1)
+      execjs
+    rufus-scheduler (3.1.2)
+    sass (3.4.9)
+    sass-css-importer (1.0.0.beta.0)
+      sass (>= 3.1)
+    sdoc (0.4.1)
+      json (~> 1.7, >= 1.7.7)
+      rdoc (~> 4.0)
+    shoulda-matchers (2.8.0)
+      activesupport (>= 3.0.0)
+    simplecov (0.9.1)
+      docile (~> 1.1.0)
+      multi_json (~> 1.0)
+      simplecov-html (~> 0.8.0)
+    simplecov-html (0.8.0)
+    spring (1.2.0)
+    sprockets (2.12.3)
+      hike (~> 1.2)
+      multi_json (~> 1.0)
+      rack (~> 1.0)
+      tilt (~> 1.1, != 1.3.0)
+    sprockets-rails (2.2.2)
+      actionpack (>= 3.0)
+      activesupport (>= 3.0)
+      sprockets (>= 2.8, < 4.0)
+    sqlite3 (1.3.10)
+    term-ansicolor (1.3.0)
+      tins (~> 1.0)
+    thin (1.6.3)
+      daemons (~> 1.0, >= 1.0.9)
+      eventmachine (~> 1.0)
+      rack (~> 1.0)
+    thor (0.19.1)
+    thread_safe (0.3.4)
+    tilt (1.4.1)
+    tins (1.3.3)
+    tzinfo (1.2.2)
+      thread_safe (~> 0.1)
+    will_paginate (3.0.7)
+    xpath (2.0.0)
+      nokogiri (~> 1.3)
+    yui-compressor (0.12.0)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  activerecord-session_store
+  awesome_nested_set
+  bcrypt
+  capybara
+  carrierwave
+  coveralls
+  database_cleaner
+  elasticsearch
+  email_spec
+  extend_method
+  factory_girl_rails
+  foreigner
+  github-markup
+  gravatarify
+  jbuilder (~> 2.0)
+  jquery-rails
+  launchy
+  letter_opener
+  mysql2
+  oauth2
+  paranoia (~> 2.0)
+  rails (= 4.1.7)
+  redcarpet
+  rspec-activemodel-mocks
+  rspec-rails
+  rufus-scheduler
+  sdoc (~> 0.4.0)
+  shoulda-matchers
+  spring
+  sqlite3
+  thin
+  web_blocks!
+  will_paginate

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,0 +1,375 @@
+# encoding: UTF-8
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# Note that this schema.rb definition is the authoritative source for your
+# database schema. If you need to create the application database on another
+# system, you should be using db:schema:load, not running all the migrations
+# from scratch. The latter is a flawed and unsustainable approach (the more migrations
+# you'll amass, the slower it'll run and the greater likelihood for issues).
+#
+# It's strongly recommended that you check this file into your version control system.
+
+ActiveRecord::Schema.define(version: 20150623003625) do
+
+  create_table "badge_groups", force: true do |t|
+    t.string   "name"
+    t.text     "description"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+    t.datetime "deleted_at"
+  end
+
+  create_table "badges", force: true do |t|
+    t.string   "name"
+    t.text     "description"
+    t.string   "image"
+    t.integer  "badge_group_id"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+    t.datetime "deleted_at"
+  end
+
+  add_index "badges", ["name"], name: "index_badges_on_name", using: :btree
+
+  create_table "comments", force: true do |t|
+    t.string   "title"
+    t.text     "body"
+    t.integer  "idea_id"
+    t.integer  "user_id",                null: false
+    t.integer  "parent_id"
+    t.integer  "lft",                    null: false
+    t.integer  "rgt",                    null: false
+    t.integer  "depth",      default: 0, null: false
+    t.datetime "created_at"
+    t.datetime "updated_at"
+    t.datetime "deleted_at"
+  end
+
+  add_index "comments", ["idea_id"], name: "index_comments_on_idea_id", using: :btree
+  add_index "comments", ["parent_id"], name: "index_comments_on_parent_id", using: :btree
+  add_index "comments", ["rgt"], name: "index_comments_on_rgt", using: :btree
+  add_index "comments", ["user_id"], name: "index_comments_on_user_id", using: :btree
+
+  create_table "competencies", force: true do |t|
+    t.string   "name"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+    t.datetime "deleted_at"
+  end
+
+  add_index "competencies", ["name"], name: "index_competencies_on_name", using: :btree
+
+  create_table "competency_users", force: true do |t|
+    t.integer  "competency_id"
+    t.integer  "user_id"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+    t.datetime "deleted_at"
+  end
+
+  create_table "event_groups", force: true do |t|
+    t.integer  "event_id"
+    t.integer  "group_id"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+    t.datetime "deleted_at"
+  end
+
+  add_index "event_groups", ["event_id", "group_id"], name: "index_event_groups_on_event_id_and_group_id", using: :btree
+  add_index "event_groups", ["event_id"], name: "index_event_groups_on_event_id", using: :btree
+  add_index "event_groups", ["group_id"], name: "event_groups_group_id_fk", using: :btree
+
+  create_table "events", force: true do |t|
+    t.integer  "user_id"
+    t.string   "name"
+    t.string   "description"
+    t.datetime "start_datetime"
+    t.datetime "stop_datetime"
+    t.string   "location"
+    t.string   "event_url"
+    t.string   "map_url"
+    t.integer  "number_going"
+    t.integer  "number_invited"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+    t.datetime "deleted_at"
+    t.string   "image"
+  end
+
+  add_index "events", ["user_id"], name: "index_events_on_user_id", using: :btree
+
+  create_table "groups", force: true do |t|
+    t.string   "name"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+    t.datetime "deleted_at"
+  end
+
+  add_index "groups", ["name"], name: "index_groups_on_name", unique: true, using: :btree
+
+  create_table "idea_competencies", force: true do |t|
+    t.integer  "idea_id"
+    t.integer  "competency_id"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+    t.datetime "deleted_at"
+  end
+
+  create_table "idea_roles", force: true do |t|
+    t.integer  "idea_id"
+    t.integer  "user_id"
+    t.boolean  "founder",    default: false
+    t.boolean  "admin",      default: false
+    t.datetime "created_at"
+    t.datetime "updated_at"
+    t.datetime "deleted_at"
+  end
+
+  add_index "idea_roles", ["created_at"], name: "index_idea_roles_on_created_at", using: :btree
+
+  create_table "idea_statuses", force: true do |t|
+    t.string   "key"
+    t.string   "name"
+    t.text     "description"
+    t.text     "icon"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+    t.datetime "deleted_at"
+  end
+
+  add_index "idea_statuses", ["key"], name: "index_idea_statuses_on_key", using: :btree
+
+  create_table "idea_votes", force: true do |t|
+    t.integer  "idea_id"
+    t.integer  "user_id"
+    t.boolean  "participate", default: false
+    t.datetime "created_at"
+    t.datetime "updated_at"
+    t.datetime "deleted_at"
+  end
+
+  add_index "idea_votes", ["created_at"], name: "index_idea_votes_on_created_at", using: :btree
+
+  create_table "ideas", force: true do |t|
+    t.integer  "idea_status_id"
+    t.string   "name"
+    t.text     "pitch"
+    t.text     "description"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+    t.datetime "deleted_at"
+  end
+
+  add_index "ideas", ["created_at"], name: "index_ideas_on_created_at", using: :btree
+
+  create_table "invites", force: true do |t|
+    t.integer  "event_id"
+    t.string   "email"
+    t.boolean  "status",     default: false
+    t.datetime "created_at"
+    t.datetime "updated_at"
+    t.datetime "deleted_at"
+    t.boolean  "responded",  default: false
+  end
+
+  add_index "invites", ["event_id", "email"], name: "index_invites_on_event_id_and_email", using: :btree
+  add_index "invites", ["event_id"], name: "index_invites_on_event_id", using: :btree
+
+  create_table "oauth2_identities", force: true do |t|
+    t.string   "provider",         null: false
+    t.string   "provider_user_id", null: false
+    t.integer  "user_id"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+    t.datetime "deleted_at"
+  end
+
+  add_index "oauth2_identities", ["provider", "provider_user_id", "deleted_at"], name: "provider_compound_key", unique: true, using: :btree
+  add_index "oauth2_identities", ["user_id"], name: "index_oauth2_identities_on_user_id", using: :btree
+
+  create_table "organizations", force: true do |t|
+    t.string   "name"
+    t.string   "shortname"
+    t.string   "url"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+    t.datetime "deleted_at"
+  end
+
+  add_index "organizations", ["name"], name: "index_organizations_on_name", using: :btree
+  add_index "organizations", ["shortname"], name: "index_organizations_on_shortname", using: :btree
+
+  create_table "positions", force: true do |t|
+    t.integer  "user_id"
+    t.integer  "organization_id"
+    t.string   "title"
+    t.string   "department"
+    t.text     "description"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+    t.datetime "deleted_at"
+  end
+
+  add_index "positions", ["department"], name: "index_positions_on_department", using: :btree
+  add_index "positions", ["title"], name: "index_positions_on_title", using: :btree
+
+  create_table "project_competencies", force: true do |t|
+    t.integer  "project_id"
+    t.integer  "competency_id"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+    t.datetime "deleted_at"
+  end
+
+  create_table "project_documents", force: true do |t|
+    t.integer  "project_id"
+    t.string   "filename"
+    t.text     "description"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+    t.datetime "deleted_at"
+  end
+
+  create_table "project_ideas", force: true do |t|
+    t.integer  "project_id"
+    t.integer  "idea_id"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+    t.datetime "deleted_at"
+  end
+
+  add_index "project_ideas", ["created_at"], name: "index_project_ideas_on_created_at", using: :btree
+
+  create_table "project_resources", force: true do |t|
+    t.integer  "project_id"
+    t.integer  "resource_id"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+    t.datetime "deleted_at"
+  end
+
+  create_table "project_roles", force: true do |t|
+    t.integer  "project_id"
+    t.integer  "user_id"
+    t.boolean  "founder",    default: false
+    t.boolean  "admin",      default: false
+    t.datetime "created_at"
+    t.datetime "updated_at"
+    t.datetime "deleted_at"
+  end
+
+  add_index "project_roles", ["created_at"], name: "index_project_roles_on_created_at", using: :btree
+
+  create_table "project_statuses", force: true do |t|
+    t.string   "key"
+    t.string   "name"
+    t.text     "description"
+    t.text     "icon"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+    t.datetime "deleted_at"
+  end
+
+  add_index "project_statuses", ["key"], name: "index_project_statuses_on_key", using: :btree
+
+  create_table "project_votes", force: true do |t|
+    t.integer  "project_id"
+    t.integer  "user_id"
+    t.boolean  "participate", default: false
+    t.datetime "created_at"
+    t.datetime "updated_at"
+    t.datetime "deleted_at"
+  end
+
+  add_index "project_votes", ["created_at"], name: "index_project_votes_on_created_at", using: :btree
+
+  create_table "projects", force: true do |t|
+    t.integer  "project_status_id"
+    t.string   "name"
+    t.text     "pitch"
+    t.text     "description"
+    t.string   "website_url"
+    t.string   "documentation_url"
+    t.string   "source_url"
+    t.string   "download_url"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+    t.datetime "deleted_at"
+    t.text     "problem_statement", limit: 16777215
+  end
+
+  add_index "projects", ["created_at"], name: "index_projects_on_created_at", using: :btree
+
+  create_table "resource_users", force: true do |t|
+    t.integer  "resource_id"
+    t.integer  "user_id"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+    t.datetime "deleted_at"
+  end
+
+  create_table "resources", force: true do |t|
+    t.string   "name"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+    t.datetime "deleted_at"
+  end
+
+  add_index "resources", ["name"], name: "index_resources_on_name", using: :btree
+
+  create_table "sessions", force: true do |t|
+    t.string   "session_id", null: false
+    t.text     "data"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+    t.datetime "deleted_at"
+  end
+
+  add_index "sessions", ["session_id"], name: "index_sessions_on_session_id", unique: true, using: :btree
+  add_index "sessions", ["updated_at"], name: "index_sessions_on_updated_at", using: :btree
+
+  create_table "user_badges", force: true do |t|
+    t.integer  "user_id"
+    t.integer  "badge_id"
+    t.boolean  "showcase",   default: false
+    t.datetime "created_at"
+    t.datetime "updated_at"
+    t.datetime "deleted_at"
+  end
+
+  create_table "users", force: true do |t|
+    t.text     "email",                               null: false
+    t.integer  "primary_position_id"
+    t.string   "name_first"
+    t.string   "name_middle"
+    t.string   "name_last",                           null: false
+    t.string   "name_suffix"
+    t.string   "website"
+    t.string   "phone_number"
+    t.string   "fax_number"
+    t.text     "mailing_address"
+    t.text     "biography"
+    t.string   "social_google"
+    t.string   "social_github"
+    t.string   "social_linkedin"
+    t.string   "social_twitter"
+    t.boolean  "super_admin",         default: false
+    t.datetime "created_at"
+    t.datetime "updated_at"
+    t.datetime "deleted_at"
+    t.string   "password_hash"
+  end
+
+  add_index "users", ["created_at"], name: "index_users_on_created_at", using: :btree
+  add_index "users", ["name_last", "name_first", "name_middle", "name_suffix"], name: "name", using: :btree
+  add_index "users", ["primary_position_id"], name: "index_users_on_primary_position_id", using: :btree
+  add_index "users", ["super_admin"], name: "index_users_on_super_admin", using: :btree
+
+  add_foreign_key "event_groups", "events", name: "event_groups_event_id_fk"
+  add_foreign_key "event_groups", "groups", name: "event_groups_group_id_fk"
+
+  add_foreign_key "invites", "events", name: "invites_event_id_fk"
+
+end


### PR DESCRIPTION
This pull request reverts the removal of `Gemfile.lock` (ae39832eaa4d35f22bc864802af85afe5c9860d7) and `db/schema.rb` (094ac02d212cf6271099fadd72a487b92ac2df2a) from versioning.

The justification for this:

1. `Gemfile.lock` contains an explicit version binding for each Ruby dependency. By removing it, the application may run with different versions of different gems on different computers, creating potentially significant conflicts. The usual practice for dealing with `Gemfile.lock` is that it *should* be versioned for applications but *should not* be version for libraries.
1. `db/schema.rb` explicitly states in its source code: *"It's strongly recommended that you check this file into your version control system."* We should probably follow the recommended convention.