### PR TITLE
Fix bug with context.user assignment

### DIFF
--- a/app/controllers/auth/oauth2_controller.rb
+++ b/app/controllers/auth/oauth2_controller.rb
@@ -31,7 +31,7 @@ module Auth
         identity.save
       end
 
-      current_user = identity.user
+      context.user = identity.user
 
       redirect_to flash[:return_to] ? flash[:return_to] : root_path
 


### PR DESCRIPTION
I have no idea why `context.user = ` was changed to `current_user =` without `def current_user=` in c6b23652b3b1f7188f4aa94a52317eb919df96fe, but it completely broke the ability to log in.