### PR TITLE
Add route definition for new account creation

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -49,6 +49,9 @@ Rails.application.routes.draw do
     get '/oauth2/:id', to: 'oauth2#return', as: :oauth2_return, constraints: lambda { |request| request.query_parameters.include? 'code' }
     get '/oauth2/:id', to: 'oauth2#launch', as: :oauth2_launch
     resource :local, controller: 'local', only: [:new, :create]
+    namespace :local do
+      resource :registration, controller: 'registration', only: [:new, :create]
+    end
   end
 
   namespace :local do


### PR DESCRIPTION
This pull request add the route definition for the new user creation method.

That user creation route, for if you want to create a local user account, will be:

> /auth/local/registration/new