### PR TITLE
Fix #127 - Shib login link from local login

### DIFF
--- a/app/views/auth/local/new.html.erb
+++ b/app/views/auth/local/new.html.erb
@@ -15,6 +15,7 @@
             <%= f.password_field :password, class: 'form-control margin-bottom', required: true %>
 
             <%= f.submit 'Login', class: 'btn btn-success' %>
+            or <%= link_to 'Register', new_auth_local_registration_url %>
 
         <% end %>
       </div>

--- a/app/views/auth/local/new.html.erb
+++ b/app/views/auth/local/new.html.erb
@@ -1,23 +1,38 @@
-<%= form_for :session, url: auth_local_url, html: { class: 'form-horizontal' } do |f| %>
+<div class="row">
 
-    <div class="form-group">
-      <%= f.label :email, class: 'col-sm-2 control-label' %>
-      <div class="col-sm-10">
-        <%= f.text_field :email, class: 'form-control', required: true %>
+  <nav class="col-sm-6">
+    <div class="panel panel-info">
+      <header class="panel-heading">
+        Local Login
+      </header>
+      <div class="panel-body">
+        <%= form_for :session, url: auth_local_url do |f| %>
+
+            <%= f.label :email %>
+            <%= f.text_field :email, class: 'form-control', required: true %>
+
+            <%= f.label :password %>
+            <%= f.password_field :password, class: 'form-control margin-bottom', required: true %>
+
+            <%= f.submit 'Login', class: 'btn btn-success' %>
+
+        <% end %>
       </div>
     </div>
+  </nav>
 
-    <div class="form-group">
-      <%= f.label :password, class: 'col-sm-2 control-label' %>
-      <div class="col-sm-10">
-        <%= f.password_field :password, class: 'form-control', required: true %>
-      </div>
+  <nav class="col-sm-6">
+    <% if Rails.application.config.respond_to?(:oauth2) and Rails.application.config.oauth2.respond_to?(:provider) and Rails.application.config.oauth2.provider.respond_to?(:shibboleth) and Rails.application.config.oauth2.provider.shibboleth.respond_to?(:enabled) and Rails.application.config.oauth2.provider.shibboleth.enabled %>
+        <div class="panel panel-primary">
+          <header class="panel-heading">
+            Campus Login
+          </header>
+          <div class="panel-body">
+            <p>Have a campus login account?</p>
+            <p><%= link_to 'Log In with Campus Account', auth_oauth2_launch_url(:shibboleth), class: 'btn btn-primary' %></p>
+          </div>
+    <% end %>
     </div>
+  </nav>
 
-    <div class="form-group">
-      <div class="col-sm-offset-2 col-sm-10">
-        <%= f.submit 'Login', class: 'btn btn-success' %>
-      </div>
-    </div>
-
-<% end %>
+</div>


### PR DESCRIPTION
This pull request adds a link to "campus login" from the "local login" - to resolve the confusion about whether you're logging in from local or campus login.

<img width="1166" alt="screen shot 2015-08-06 at 10 18 17 pm" src="https://cloud.githubusercontent.com/assets/761092/9129171/17e4eb5c-3c89-11e5-9c02-37482e13e798.png">
