### PR TITLE
add duplicate OS X entry in competencies and name the name field unique

### DIFF
--- a/db/migrate/20150911202235_remove_dupe_add_unique_index.rb
+++ b/db/migrate/20150911202235_remove_dupe_add_unique_index.rb
@@ -1,0 +1,11 @@
+class RemoveDupeAddUniqueIndex < ActiveRecord::Migration
+  def change
+    while Competency.where(:name => "OS X").count > 1
+      dupe = Competency.where(:name => "OS X").max
+      dupe.destroy
+    end
+
+    remove_index :competencies, :name
+    add_index :competencies, :name, :unique => true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150904173042) do
+ActiveRecord::Schema.define(version: 20150911202235) do
 
   create_table "badge_categories", force: true do |t|
     t.string   "name"
@@ -83,7 +83,7 @@ ActiveRecord::Schema.define(version: 20150904173042) do
     t.datetime "deleted_at"
   end
 
-  add_index "competencies", ["name"], name: "index_competencies_on_name", using: :btree
+  add_index "competencies", ["name"], name: "index_competencies_on_name", unique: true, using: :btree
 
   create_table "competency_users", force: true do |t|
     t.integer  "competency_id"


### PR DESCRIPTION
I think the migration that adds OS X must have ran twice 