### PR TITLE
Refresh indices after relations are set

### DIFF
--- a/app/controllers/ideas_controller.rb
+++ b/app/controllers/ideas_controller.rb
@@ -28,6 +28,7 @@ class IdeasController < ApplicationController
     idea = Idea.create params[:idea].permit(:name, :pitch, :description, :idea_status_id)
     idea.idea_roles << IdeaRole.new(user: current_user, founder: true, admin: true)
     idea.competency_ids = params[:idea][:competencies]
+    idea.refresh_index!
 
     current_user.alter_points :ideas, 3
 
@@ -45,6 +46,7 @@ class IdeasController < ApplicationController
   def update
     @idea.update params[:idea].permit(:name, :pitch, :description, :idea_status_id)
     @idea.competency_ids = params[:idea][:competencies]
+    @idea.refresh_index!
     redirect_to params[:return_to] ? params[:return_to] : idea_url(@idea)
   end
 

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -33,6 +33,7 @@ class ProjectsController < ApplicationController
       @project.idea_ids       = params[:project][:ideas]
       @project.competency_ids = params[:project][:competencies]
       @project.resource_ids   = params[:project][:resources]
+      @project.refresh_index!
 
       current_user.alter_points :projects, 5
 
@@ -54,6 +55,7 @@ class ProjectsController < ApplicationController
       @project.idea_ids       = params[:project][:ideas]
       @project.competency_ids = params[:project][:competencies]
       @project.resource_ids   = params[:project][:resources]
+      @project.refresh_index!
 
       redirect_to params[:return_to] || project_url(@project)
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -75,6 +75,7 @@ class UsersController < ApplicationController
     @user.update data
     @user.competency_ids = params[:user][:competencies].split(',')
     @user.resource_ids = params[:user][:resources]
+    @user.refresh_index!
 
     if params[:primary_position_organization_id]
       if params[:primary_position_organization_id] != '0'

--- a/lib/application/index.rb
+++ b/lib/application/index.rb
@@ -26,6 +26,11 @@ module Application
       index_client.delete index_identity
     end
 
+    def refresh_index!
+      destroy_index! if index_exists?
+      create_index!
+    end
+
     def index_exists?
       index_client.exists index_identity
     end


### PR DESCRIPTION
Currently, indices are set when `after_save`.

Unfortunately, what this leads to are indices that are not actually up to date:

```ruby
idea = Idea.create params[:idea].permit(:name, :pitch, :description, :idea_status_id)
idea.idea_roles << IdeaRole.new(user: current_user, founder: true, admin: true)
idea.competency_ids = params[:idea][:competencies]
```

The solution to this problem is to introduce a new method to refresh the indices:

```ruby
def refresh_index!
  destroy_index! if index_exists?
  create_index!
end
```

And then call it after the relations are locked in:

```ruby
idea = Idea.create params[:idea].permit(:name, :pitch, :description, :idea_status_id)
idea.idea_roles << IdeaRole.new(user: current_user, founder: true, admin: true)
idea.competency_ids = params[:idea][:competencies]
idea.refresh_index!
```