### PR TITLE
Fix #31 - Search Scoring

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -5,6 +5,7 @@ class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
 
   include ApplicationHelper
+  include SearchHelper
 
   class << self
     include ExtendMethod

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -14,11 +14,34 @@ class HomeController < ApplicationController
   private
 
   def dashboard
+
+    @ideas = perform_search { |query|
+      query.type 'ideas'
+      query.limit 5
+    }.map { |r| r.model }
+
+    @projects = perform_search { |query|
+      query.type 'projects'
+      query.limit 5
+    }.map { |r| r.model }
+
     render 'dashboard'
   end
 
   def welcome
+
+    @ideas = perform_search { |query|
+      query.type 'ideas'
+      query.limit 5
+    }.map { |r| r.model }
+
+    @projects = perform_search { |query|
+      query.type 'projects'
+      query.limit 5
+    }.map { |r| r.model }
+
     render 'welcome'
+
   end
 
 end

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -1,107 +1,26 @@
 class SearchController < ApplicationController
 
-  TYPE_MAP = {
-    'ideas' => {
-        :class => Idea,
-        :type_name => 'Idea',
-        :title_method => :name,
-        :description_proc => Proc.new(){ |idea| idea.pitch }
-    },
-    'projects' => {
-        :class => Project,
-        :type_name => 'Project',
-        :title_method => :name,
-        :description_proc => Proc.new(){ |project| project.pitch }
-    },
-    'users' => {
-        :class => User,
-        :type_name => 'Person',
-        :title_method => :display_name,
-        :description_proc => Proc.new(){ |user|
-          if user.primary_position
-            "#{user.primary_position.title}, #{user.primary_position.department} ( #{user.primary_position.organization.shortname} )"
-          else
-            nil
-          end
-        }
-    }
-  }
-
   def default
 
-    search_body = {}
+    p = params
 
-    search_body['size'] = params[:limit] if params.include?(:limit)
-    search_body['from'] = params[:offset] if params.include?(:offset)
+    @results = perform_search { |query|
 
-    search_body['query'] = {
-      "function_score" => {
-        "query" => {
-          'bool' => {
-            'should' => [
-              {
-                'multi_match' => {
-                  'query' => params[:query],
-                  'type' => 'phrase_prefix',
-                  'fields' => ['title', 'description', 'competencies']
-                }
-              }
-            ]
-          }
-        },
-        "functions": [
-          {
-            "exp": {
-              "created_at": {
-                "origin": Time.now.strftime('%Y-%m-%dT%H:%M:%S%:z'), #"2015-09-27T23:50:00",
-                "scale": "180d",
-                "offset": "90d",
-                "decay": 0.6
-              }
-            }
-          },
-          {
-            "field_value_factor": {
-              "field": "votes",
-              "factor": 4, # gives ideas and projects as 3x weight over users
-              "modifier": "sqrt",
-              "missing": 0.25
-            }
-          }
-        ],
-        "score_mode": "multiply" # default
-      }
-    }
+      query.match p[:query]
 
-    index_name = Rails.application.config.elasticsearch_config[:index_name]
-
-    search_properties = {
-      index: index_name,
-      body: search_body
-    }
-
-    if params[:type] and params[:type] != 'all'
-      search_properties[:type] = params[:type]
-    end
-
-    res = Rails.application.config.elasticsearch_client.search search_properties
-
-    @results = res['hits']['hits'].map { |r|
-      begin
-        model = TYPE_MAP[r['_type']][:class].find(r['_id'])
-        OpenStruct.new({
-          :model => model,
-          :title => model.send(TYPE_MAP[r['_type']][:title_method]),
-          :type => TYPE_MAP[r['_type']][:type_name],
-          :score => r['_score'],
-          :description => TYPE_MAP[r['_type']][:description_proc].call(model),
-          :r => r
-        })
-      rescue => e
-        puts e
-        nil
+      if p[:type] and p[:type] != 'all'
+        query.type p[:type]
       end
-    }.delete_if { |o| o.nil? }
+
+      if p.include?(:limit)
+        query.limit = p[:limit]
+      end
+
+      if p.include?(:offset)
+        query.offset = p[:offset]
+      end
+
+    }
 
     render 'results'
 

--- a/app/helpers/search_helper.rb
+++ b/app/helpers/search_helper.rb
@@ -1,0 +1,136 @@
+module SearchHelper
+
+  class ElasticsearchHelper
+
+    TYPE_MAP = {
+        'ideas' => {
+            :class => Idea,
+            :type_name => 'Idea',
+            :title_method => :name,
+            :description_proc => Proc.new(){ |idea| idea.pitch }
+        },
+        'projects' => {
+            :class => Project,
+            :type_name => 'Project',
+            :title_method => :name,
+            :description_proc => Proc.new(){ |project| project.pitch }
+        },
+        'users' => {
+            :class => User,
+            :type_name => 'Person',
+            :title_method => :display_name,
+            :description_proc => Proc.new(){ |user|
+              if user.primary_position
+                "#{user.primary_position.title}, #{user.primary_position.department} ( #{user.primary_position.organization.shortname} )"
+              else
+                nil
+              end
+            }
+        }
+    }
+
+    def initialize
+      @search_body = {}
+      @should_queries = []
+      index_name = Rails.application.config.elasticsearch_config[:index_name]
+      @search_properties = {
+          index: index_name
+      }
+    end
+
+    def match phrase
+      @should_queries.push({
+        'multi_match' => {
+          'query' => phrase,
+          'type' => 'phrase_prefix',
+          'fields' => ['title', 'description', 'competencies']
+        }
+      })
+    end
+
+    def type val
+      @search_properties[:type] = val
+    end
+
+    def limit val
+      @search_body['size'] = val
+    end
+
+    def offset val
+      @search_body['from'] = val
+    end
+
+    def generate_body!
+      @search_body['query'] = {
+        "function_score" => {
+            "query" => {
+                'bool' => {
+                    'should' => @should_queries
+                }
+            },
+            "functions": [
+                {
+                    "exp": {
+                        "created_at": {
+                            "origin": Time.now.strftime('%Y-%m-%dT%H:%M:%S%:z'), #"2015-09-27T23:50:00",
+                            "scale": "180d",
+                            "offset": "90d",
+                            "decay": 0.6
+                        }
+                    }
+                },
+                {
+                    "field_value_factor": {
+                        "field": "votes",
+                        "factor": 4, # gives ideas and projects as 3x weight over users
+                        "modifier": "sqrt",
+                        "missing": 0.25
+                    }
+                }
+            ],
+            "score_mode": "multiply" # default
+        }
+      }
+    end
+
+    def finalize_search_properties!
+      generate_body!
+      @search_properties[:body] = @search_body
+    end
+
+    def results
+
+      finalize_search_properties!
+
+      res = Rails.application.config.elasticsearch_client.search @search_properties
+
+      res['hits']['hits'].map { |r|
+        begin
+          model = TYPE_MAP[r['_type']][:class].find(r['_id'])
+          OpenStruct.new({
+                             :model => model,
+                             :title => model.send(TYPE_MAP[r['_type']][:title_method]),
+                             :type => TYPE_MAP[r['_type']][:type_name],
+                             :score => r['_score'],
+                             :description => TYPE_MAP[r['_type']][:description_proc].call(model),
+                             :r => r
+                         })
+        rescue => e
+          puts e
+          nil
+        end
+      }.delete_if { |o| o.nil? }
+
+    end
+
+  end
+
+  def perform_search &block
+
+    helper = ElasticsearchHelper.new
+    helper.instance_exec helper, &block
+    helper.results
+
+  end
+
+end

--- a/app/models/idea.rb
+++ b/app/models/idea.rb
@@ -73,7 +73,8 @@ class Idea < ActiveRecord::Base
   def index_body
     body = prepare_index_body do
       serializable_hash.merge({
-        'competencies' => competencies.map(){ |c| c.name }
+        'competencies' => competencies.map(){ |c| c.name },
+        'votes' => idea_votes.count
       })
     end
     body

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -83,7 +83,8 @@ class Project < ActiveRecord::Base
   def index_body
     body = prepare_index_body do
       serializable_hash.merge({
-        'competencies' => competencies.map(){ |c| c.name }
+        'competencies' => competencies.map(){ |c| c.name },
+        'votes' => project_votes.count
       })
     end
     body

--- a/app/views/home/dashboard.html.erb
+++ b/app/views/home/dashboard.html.erb
@@ -12,7 +12,7 @@
       </header>
       <div class="panel-body">
         <ul>
-          <% Idea.top_voted(5).each do |idea| %>
+          <% @ideas.each do |idea| %>
             <li><%= link_to idea.name, idea %></li>
           <% end %>
         </ul>
@@ -26,7 +26,7 @@
       </header>
       <div class="panel-body">
         <ul>
-          <% Project.top_voted(5).each do |project| %>
+          <% @projects.each do |project| %>
             <li><%= link_to project.name, project %></li>
           <% end %>
         </ul>

--- a/app/views/home/welcome.html.erb
+++ b/app/views/home/welcome.html.erb
@@ -12,7 +12,7 @@
         </span>
       </h1>
       <ul class="list-group">
-        <% Project.top_voted(5).each do |idea| %>
+        <% @projects.each do |idea| %>
           <li class="list-group-item"><%= link_to idea.name, idea %></li>
         <% end %>
       </ul>
@@ -28,7 +28,7 @@
         </span>
       </h1>
       <ul class="list-group list-group-secondary">
-        <% Idea.top_voted(5).each do |idea| %>
+        <% @ideas.each do |idea| %>
           <li class="list-group-item"><%= link_to idea.name, idea %></li>
         <% end %>
       </ul>

--- a/db/migrate/20151011164349_reset_indices_to_add_votes_to_projects_and_ideas.rb
+++ b/db/migrate/20151011164349_reset_indices_to_add_votes_to_projects_and_ideas.rb
@@ -1,0 +1,21 @@
+class ResetIndicesToAddVotesToProjectsAndIdeas < ActiveRecord::Migration
+  def change
+
+    [
+        { name: 'idea', class: Idea, label: :name },
+        { name: 'project', class: Project, label: :name },
+        { name: 'user', class: User, label: :display_name }
+    ].each do |o|
+      o[:class].all.each do |obj|
+        if obj.index_exists?
+          puts "[#{o[:name]} - reset index - #{obj.id}] #{obj.send(o[:label])}"
+          obj.destroy_index!
+        end
+        puts "[#{o[:name]} - create index - #{obj.id}] #{obj.send(o[:label])}"
+        obj.create_index!
+      end
+    end
+
+
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150911202235) do
+ActiveRecord::Schema.define(version: 20151011164349) do
 
   create_table "badge_categories", force: true do |t|
     t.string   "name"


### PR DESCRIPTION
This pull request resolves the issue discussed in #31, as well as implements the same search scoring for the dashboard Projects and Ideas lists. For a discussion of how the search scoring works, please read my comments in #31.

One item worth calling out here explicitly though from a code perspective is the search helper. I implemented a simple DSL that makes it easy to write searches without getting bogged down with the complexity of the Elasticsearch query language, while also maintaining consistency around how weighting is done regardless of where the search is being executed.

Here's a simple example from the `HomeController` that gets the 5 highest-scored projects with scoring based on newness and popularity:

```ruby
@projects = perform_search { |query|

  query.type 'projects'
  query.limit 5

}.map { |r| r.model }
```

Here's a more complex example from the SearchController that matches results against a search query, optionally filtering by a type, and supporting pagination with limit and/or offset, scoring based on match similarity, newness, popularity and type (positive bias towards projects and ideas).

```ruby
@results = perform_search { |query|

  query.match p[:query]

  if p[:type] and p[:type] != 'all'
    query.type p[:type]
  end

  if p.include?(:limit)
    query.limit = p[:limit]
  end

  if p.include?(:offset)
    query.offset = p[:offset]
  end

}
```

As a note, the `perform_search` function returns an array of `OpenStruct` objects with the properties:

* `model` the actual ActiveRecord model for the result
* `title` the title for the model based on its type (such as `display_name` for a user or `name` for an idea)
* `type` a display name for the result (such as "Idea" or "Project")
* `description` the description computed for a model based on its type
* `score` the score computed by likeness, newness, popularity and type weighting
* `r` the raw result object from elasticsearch

Keep in mind that the array may have results of multiple types (so this array might have some models of class `User` while others of type `Idea` and `Project`). That's why we have `title`, `type` and `description` so that, even though the way they're computed may be different, they all share a common interface for the way it's presented in places like search results.

@stevenolen before it can be merged and deployed, **Elasticsearch must be updated to 1.7.1.**