### PR TITLE
Update WebBlocks dependency version in Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -45,7 +45,7 @@ gem 'gravatarify'
 gem 'extend_method'
 
 # Use web_blocks to compile Javascript assets
-gem 'web_blocks', :git => 'https://github.com/WebBlocks/WebBlocks.git'
+gem 'web_blocks', :git => 'https://github.com/WebBlocks/WebBlocks.git', :tag => '2.0.4.dev'
 
 # Test coverage
 gem 'coveralls', :require => false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,7 @@
 GIT
   remote: https://github.com/WebBlocks/WebBlocks.git
-  revision: 2e871cbebef6fa72c1a4d54a61bd60fc7fe64f62
+  revision: e208bb3afae7ad45d56212f2b1a16a06969a39fe
+  tag: 2.0.4.dev
   specs:
     web_blocks (2.0.4.dev)
       compass


### PR DESCRIPTION
Pin WebBlocks at 2.0.4.dev in Gemfile for Travis and also more explicit documentation about the dependency version itself. The previous version of the app only forced the WebBlocks version in Gemfile.lock.