### PR TITLE
Issue #123 - Clean up 'how to get points' for engagement meter page

### DIFF
--- a/app/views/home/engagement.html.erb
+++ b/app/views/home/engagement.html.erb
@@ -15,18 +15,18 @@
     <h1>How to get points:</h1>
     <div class="panel panel-default">
       <div class="panel-body">
-        <p>1) Setting up a Profile ADD 2 points; DELETE a profile SUBTRACT 2 points</p>
-        <p>2) Create a project ADD 5 points ; DELETE a project SUBTRACT 5 points</p>
-        <p>4) Like a project ADD 1 point</p>
-        <p>5) Comment on a project - ADD 2 points</p>
-        <p>3) Create an Idea ADD 3 points; DELETE an Idea SUBTRACT 3 points</p>
-        <p>4) Like an Idea ADD 1 point</p>
-        <p>5) Comment on an idea - ADD 2 points</p>
-        <p>6) Create a Group ADD 3 points ( DELETE a group - can only be done - if you are the only person in the group)</p>
-        <p>7) Join a Group ADD 1 point; LEAVE a group SUBTRACT 1 point</p>
-        <p>8) Awarding a GOLD Sautter Award for your campus = 50 points for you and your campus</p>
-        <p>9) Awarding a SILVER Sautter Award for your campus = 25 points for you and your campus</p>
-        <p>10) Removing an award subtracts those points</p>
+        <ol>
+          <li>Create a project: ADD 5 points; delete a project: SUBTRACT 5 points</li>
+          <li>Like a project: ADD 1 point</li>
+          <li>Comment on a project: ADD 2 points</li>
+          <li>Create an idea: ADD 3 points; delete an idea: SUBTRACT 3 points</li>
+          <li>Like an idea: ADD 1 point</li>
+          <li>Comment on an idea: ADD 2 points</li>
+          <li>Create a group: ADD 3 points; delete a group: SUBTRACT 3 points (can only be done if you are the only person in the group)</li>
+          <li>Join a group: ADD 1 point; leave a group: SUBTRACT 1 point</li>
+          <li>Receive a Gold Sautter Award: ADD 50 points</li>
+          <li>Receive a Silver Sautter Award: ADD 25 points</li>
+        </ol>
       </div>
     </div>
   </div>


### PR DESCRIPTION
Removed the items about setting up a profile (we never defined what that means) and losing awards (we don't allow removal of awards).

I also cleaned up the text a bit to make it more consistent.