### PR TITLE
Issue #133

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -52,6 +52,14 @@ class ApplicationController < ActionController::Base
     flash[:page_alert_type] = 'danger'
   end
 
+  # Sends the user back from whence they came with an error message
+  def redirect_forbidden message
+    redirect_to(request.referrer || :root, flash: {
+      page_alert_type: "danger",
+      page_alert: message
+    })
+  end
+
   private
   def set_mailer_host
     # Override email URLs to always use the host that served the request

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -11,13 +11,13 @@ class UsersController < ApplicationController
     @user = User.find(params[:id])
 
     unless @user.is_viewable_by? current_user
-      redirect_to :root
+      redirect_forbidden "This user's profile is private."
     end
   end
 
   before_action only: [:edit, :update, :destroy] do
     unless @user.is_editable_by? current_user
-      redirect_to :root
+      redirect_forbidden "You cannot edit this user."
     end
   end
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -22,11 +22,10 @@ class UsersController < ApplicationController
   end
 
   def index
-    # Super admins see all users, normal users only see publicly listed ones
-    @users = (current_user.super_admin ? User : User.public_profiles)
-      .includes(:positions, :organizations)
-      .order(:name_last, :name_first)
-      .paginate(page: params[:page], per_page: 15)
+    # Show all users (view hides sensitive information from hidden ones)
+    @users = User.includes(:positions, :organizations)
+                 .order(:name_last, :name_first)
+                 .paginate(page: params[:page], per_page: 15)
   end
 
   def show

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -1,2 +1,9 @@
 module UsersHelper
+  def link_to_user user
+    if current_user && user.is_viewable_by?(current_user)
+      link_to user.display_name, user
+    else
+      content_tag :span, user.display_name, :title => "This user's profile is hidden."
+    end
+  end
 end

--- a/app/views/badges/show.html.erb
+++ b/app/views/badges/show.html.erb
@@ -71,7 +71,7 @@
               <% else %>
                 <%= image_tag "data:img/png;base64,#{user_badge.user.profile_image}", size: '40x40', secure: true %>
               <% end %>
-              <%= link_to user_badge.user.display_name, user_badge.user %>
+              <%= link_to_user user_badge.user %>
             </li>
           <% end %>
         </ul>

--- a/app/views/comments/_comment.html.erb
+++ b/app/views/comments/_comment.html.erb
@@ -1,6 +1,6 @@
 <div class="well">
   <h3><%= comment.title %></h3>
-  <p class="text-muted"><%= link_to comment.user.display_name, comment.user %>&nbsp;<%= local_time(comment.created_at, '%B, %d %Y %H:%M:%S') %></p>
+  <p class="text-muted"><%= link_to_user comment.user %>&nbsp;<%= local_time(comment.created_at, '%B, %d %Y %H:%M:%S') %></p>
   <blockquote>
   	<p>&nbsp;<%= comment.body %>&nbsp;
     <% if comment.edited? %>

--- a/app/views/competencies/show.html.erb
+++ b/app/views/competencies/show.html.erb
@@ -45,7 +45,7 @@
         <div class="panel-body">
           <ul class="list-unstyled">
             <% @competency.users.order(name_last: :asc, name_first: :asc).each do |user| %>
-              <li><%= link_to user.display_name(:lf), user %></li>
+              <li><%= link_to_user user %></li>
             <% end %>
           </ul>
         </div>

--- a/app/views/groups/show.html.erb
+++ b/app/views/groups/show.html.erb
@@ -84,7 +84,7 @@
           <% @group.users.each do |user| %>
             <li class="list-group-item">
               <%= gravatar_tag user.email, size: 40, secure: true, html: { class: "list-avatar" } %>
-              <%= link_to user.display_name, user %>
+              <%= link_to_user user %>
             </li>
           <% end %>
         </ul>

--- a/app/views/ideas/index.html.erb
+++ b/app/views/ideas/index.html.erb
@@ -156,7 +156,7 @@
             Proposed
             <% if idea.idea_roles.founders.count > 0 %>
               by
-              <%= idea.idea_roles.founders.includes(:user).map { |r| link_to r.user.display_name, r.user }.to_sentence.html_safe %>
+              <%= idea.idea_roles.founders.includes(:user).map { |r| link_to_user r.user }.to_sentence.html_safe %>
             <% end %>
             on
             <%= idea.created_at.strftime("%B %d, %Y") %>

--- a/app/views/ideas/show.html.erb
+++ b/app/views/ideas/show.html.erb
@@ -175,7 +175,7 @@
           <div class="panel-body">
             <ul>
               <% @idea.idea_roles.founders.each do |idea_role| %>
-                <li><%= link_to idea_role.user.display_name, idea_role.user %></li>
+                <li><%= link_to_user idea_role.user %></li>
               <% end %>
             </ul>
           </div>
@@ -194,7 +194,7 @@
           <div class="panel-body">
             <ul>
               <% @idea.idea_votes.take(5).each do |idea_vote| %>
-                <li><%= link_to idea_vote.user.display_name, idea_vote.user %><% if idea_vote.participate %> <strong style="font-size: 1.2rem">&#9734;</strong><% end %></li>
+                <li><%= link_to_user idea_vote.user %><% if idea_vote.participate %> <strong style="font-size: 1.2rem">&#9734;</strong><% end %></li>
               <% end %>
             </ul>
           </div>

--- a/app/views/local/users/index.html.erb
+++ b/app/views/local/users/index.html.erb
@@ -17,7 +17,7 @@
   <tbody>
   <% @users.each do |user| %>
       <tr>
-        <td><%= link_to user.display_name(:lf), user_url(user) %></td>
+        <td><%= link_to_user user %></td>
         <td><%= link_to 'Change Password', edit_local_user_url(user) %></td>
         <td><%= link_to 'Edit Profile', edit_user_url(user) %></td>
         <td><%= link_to 'Delete Account', local_user_url(user), method: :delete,

--- a/app/views/projects/index.html.erb
+++ b/app/views/projects/index.html.erb
@@ -140,7 +140,7 @@
             Started
             <% if project.project_roles.founders.count > 0 %>
               by
-              <%= project.project_roles.founders.includes(:user).map { |r| link_to r.user.display_name, r.user }.to_sentence.html_safe %>
+              <%= project.project_roles.founders.includes(:user).map { |r| link_to_user r.user }.to_sentence.html_safe %>
             <% end %>
             on
             <%= project.created_at.strftime("%B %d, %Y") %>

--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -29,7 +29,7 @@
           </h5>
           <ul class="list-unstyled">
             <% @project.project_roles.founders.each do |project_role| %>
-              <li><%= link_to project_role.user.display_name, project_role.user %></li>
+              <li><%= link_to_user project_role.user %></li>
             <% end %>
           </ul>
           <% end %>
@@ -102,7 +102,7 @@
             <div class="panel-body">
               <ul class="list-unstyled">
                 <% @project.users.order(name_last: :asc, name_first: :asc).each do |user| %>
-                  <li><%= link_to user.display_name(:fl), user %></li>
+                  <li><%= link_to_user user %></li>
                 <% end %>
               </ul>
             </div>
@@ -230,7 +230,7 @@
             <ul class="scroller-collapser">
               <% @project.project_votes.non_participants.each do |project_vote| %>
                 <li>
-                  <%= link_to project_vote.user.display_name, project_vote.user %>
+                  <%= link_to_user project_vote.user %>
                 </li>
               <% end %>
             </ul>
@@ -253,7 +253,7 @@
             <ul class="scroller-collapser">
               <% @project.project_votes.participants.each do |project_vote| %>
                 <li>
-                  <%= link_to project_vote.user.display_name, project_vote.user %>
+                  <%= link_to_user project_vote.user %>
                 </li>
               <% end %>
             </ul>

--- a/app/views/resources/show.html.erb
+++ b/app/views/resources/show.html.erb
@@ -28,7 +28,7 @@
         <div class="panel-body">
           <ul class="list-unstyled">
             <% @resource.users.each do |user| %>
-              <li><%= link_to user.display_name(:lf), user %></li>
+              <li><%= link_to_user user %></li>
             <% end %>
           </ul>
         </div>

--- a/app/views/users/badges/index.html.erb
+++ b/app/views/users/badges/index.html.erb
@@ -6,7 +6,7 @@
 
 <h2 class="text-center clear-both">
   Badges and Awards
-  <br><small><%= link_to @user.display_name(:fl), @user %></small>
+  <br><small><%= link_to_user @user %></small>
 </h2>
 
 <ul class="badges">

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -16,57 +16,69 @@
       </tr>
     </thead>
     <tbody>
-    <% @users.each do |user| %>
-    <tr>
-      <% if current_user %>
-        <td class="avatar-cell">
-          <% if user.profile_image.blank? %>
-            <%#= gravatar_tag user.email, size: 40, secure: true %>
-            <%= image_tag "/images/profile/default-80x80.png", size: '50x50', class: "small-wave"  %>
+      <% @users.each do |user| %>
+        <tr>
+          <% if user.is_viewable_by? current_user %>
+            <td class="avatar-cell">
+              <% if user.profile_image.blank? %>
+                <%= image_tag "/images/profile/default-80x80.png", size: '50x50', class: "small-wave"  %>
+              <% else %>
+                <%= image_tag "data:img/png;base64,#{user.profile_image}", size: '50x50', secure: true %>
+              <% end %>
+            </td>
+            <td>
+              <%= link_to_user user %>
+            </td>
+            <td>
+              <%= user.primary_position ? user.primary_position.title : '' %>
+            </td>
+            <% if user.primary_organization %>
+              <td><%= image_tag "/images/organizations/#{user.primary_organization.name}.png", size: "82x30" %></td>
+            <% else %>
+              <td></td>
+            <% end %>
+            <td>
+              <%= user.created_at.strftime("%B %d, %Y") %>
+            </td>
+            <td>
+              <% if user.website %>
+                <%= link_to user.website_url, target: '_blank' do %>
+                  <%= image_tag "/images/links/www.png", alt: "WWW", class: "social-icon" %>
+                <% end %>
+              <% end %>
+              <% if user.social_github %>
+                <%= link_to user.social_github_url, target: '_blank' do %>
+                  <%= image_tag "/images/links/github.png", alt: "GitHub", class: "social-icon" %>
+                <% end %>
+              <% end %>
+              <% if user.social_google %>
+                <%= link_to user.social_google_url, target: '_blank' do %>
+                  <%= image_tag "/images/links/google.png", alt: "Google+", class: "social-icon" %>
+                <% end %>
+              <% end %>
+              <% if user.social_linkedin %>
+                <%= link_to user.social_linkedin_url, target: '_blank' do %>
+                  <%= image_tag "/images/links/linkedin.png", alt: "LinkedIn", class: "social-icon" %>
+                <% end %>
+              <% end %>
+              <% if user.social_twitter %>
+                <%= link_to user.social_twitter_url, target: '_blank' do %>
+                  <%= image_tag "/images/links/twitter.png", alt: "Twitter", class: "social-icon" %>
+                <% end %>
+              <% end %>
+            </td>
+
           <% else %>
-            <%= image_tag "data:img/png;base64,#{user.profile_image}", size: '50x50', secure: true %>
+            <td class="avatar-cell"></td>
+            <td>
+              <%= link_to_user user %>
+            </td>
+            <td colspan="4">
+              <em>This user&apos;s profile is hidden.</em>
+            </td>
           <% end %>
-        </td>
-      <% else %>
-        <td class="avatar-cell"></td>
+        </tr>
       <% end %>
-      <td><%= link_to user.display_name, user_url(user) %></td>
-      <td><%= user.primary_position ? user.primary_position.title : '' %></td>
-      <% if user.primary_organization %>
-      <td><%= image_tag "/images/organizations/#{user.primary_organization.name}.png", size: "82x30" %></td>
-      <% else %>
-      <td></td>
-      <% end %>
-      <td><%= user.created_at.strftime("%B %d, %Y") %></td>
-      <td>
-        <% if user.website %>
-          <%= link_to user.website_url, target: '_blank' do %>
-            <%= image_tag "/images/links/www.png", alt: "WWW", class: "social-icon" %>
-          <% end %>
-        <% end %>
-        <% if user.social_github %>
-          <%= link_to user.social_github_url, target: '_blank' do %>
-            <%= image_tag "/images/links/github.png", alt: "GitHub", class: "social-icon" %>
-          <% end %>
-        <% end %>
-        <% if user.social_google %>
-          <%= link_to user.social_google_url, target: '_blank' do %>
-            <%= image_tag "/images/links/google.png", alt: "Google+", class: "social-icon" %>
-          <% end %>
-        <% end %>
-        <% if user.social_linkedin %>
-          <%= link_to user.social_linkedin_url, target: '_blank' do %>
-            <%= image_tag "/images/links/linkedin.png", alt: "LinkedIn", class: "social-icon" %>
-          <% end %>
-        <% end %>
-        <% if user.social_twitter %>
-          <%= link_to user.social_twitter_url, target: '_blank' do %>
-            <%= image_tag "/images/links/twitter.png", alt: "Twitter", class: "social-icon" %>
-          <% end %>
-        <% end %>
-      </td>
-    </tr>
-    <% end %>
     </tbody>
   </table>
 </div>


### PR DESCRIPTION
- Show hidden users as plain text rather than links
- Hovering over the plain text gives explanation why they're hidden
- If trying to view a hidden user, show a friendly error